### PR TITLE
Web accessibility manual testing

### DIFF
--- a/docs/testing/web/colour-contrast.md
+++ b/docs/testing/web/colour-contrast.md
@@ -1,0 +1,10 @@
+# Colour contrast
+
+We must always meet the WCAG 2.0 AAA standard for colour contrast.
+
+The standard requires a contrast ratio of at least 7:1 for normal text and 4.5:1 for large text.
+
+Large text is consider 24px or larger (18.66px or larger for bold text).
+
+You can test a combination of background and foreground colours using the [WebAIM colour contrast
+checker](https://webaim.org/resources/contrastchecker/)

--- a/docs/testing/web/keyboard-navigation.md
+++ b/docs/testing/web/keyboard-navigation.md
@@ -1,0 +1,37 @@
+# Keyboard navigation
+
+Some people cannot, or choose not to, use a mouse or trackpad. The may instead browse the web using their keyboards
+exclusively, which we should facilitate.
+
+## Links, forms and buttons
+
+- All links, form fields and buttons should be accessible using the Tab key 
+- Buttons should be activated using both the Enter and Space keys
+- Links should be activated using the Enter key
+- Consider a default action for pressing the Enter key while a form field is in focus
+
+## Dropdown menus
+
+- Dropdown menus should be expanded using the Enter key
+- When a dropdown menu is expanded, links within the menu should be accessible using the Tab key
+- When a dropdown menu is collapsed, links within the menu should not be accessible using the Tab key
+- Dropdown menus should be collapsed using the Escape key
+
+## Modal dialogs
+
+- Modal dialogs should be closed using the Escape key
+- When a modal dialog is open, the focus should be trapped (i.e. pressing the Tab key should never move focus outside of
+the dialog) until the dialog is closed
+
+## Tab lists
+
+- Tabs (i.e. elements with `role=tab`) should be accessible using the Tab key
+- Tabs should be activated using the Enter key
+- When a tab panel becomes active, focus should be moved into that tab panel
+- Focussable elements in the active tab panel should be accessible using the Tab key
+- Focussable elements in hidden tab panels should not be accessible using the Tab key
+
+## Carousels
+
+- Consider implementing intuitive shortcuts, such as using the Left and Right cursor keys to move backwards and forwards
+through the carousel

--- a/docs/testing/web/screen-readers.md
+++ b/docs/testing/web/screen-readers.md
@@ -1,0 +1,11 @@
+# Screen readers
+
+Screen readers provide an audio representation of a website. They enable people with a vision impairment to navigate and
+perceive the meaningful content of the website.
+
+We must ensure that all our content is navigable and represented in a meaningful way using a screen reader.
+
+Please test your work using at least one of these combinations:
+
+- OSX + Chrome + [VoiceOver](https://www.apple.com/voiceover/info/guide/_1131.html)
+- Windows + Firefox + [NVDA](https://dequeuniversity.com/screenreaders/nvda-keyboard-shortcuts)

--- a/docs/testing/web/screen-readers.md
+++ b/docs/testing/web/screen-readers.md
@@ -5,7 +5,13 @@ perceive the meaningful content of the website.
 
 We must ensure that all our content is navigable and represented in a meaningful way using a screen reader.
 
+Although we don't maintain a list of screen readers we support, the best screen readers to test with are:
+
+- [VoiceOver](https://www.apple.com/voiceover/info/guide/_1131.html) (OSX)
+- [NVDA](https://dequeuniversity.com/screenreaders/nvda-keyboard-shortcuts) (Windows)
+
 Please test your work using at least one of these combinations:
 
-- OSX + Chrome + [VoiceOver](https://www.apple.com/voiceover/info/guide/_1131.html)
-- Windows + Firefox + [NVDA](https://dequeuniversity.com/screenreaders/nvda-keyboard-shortcuts)
+- OSX + Safari + VoiceOver
+- OSX + Chrome + VoiceOver
+- Windows + Firefox + NVDA

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,4 +15,5 @@ pages:
     - Web:
       - Keyboard navigation: 'testing/web/keyboard-navigation.md'
       - Screen readers: 'testing/web/screen-readers.md'
+      - Colour contrast: 'testing/web/colour-contrast.md'
 theme: readthedocs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,4 +11,8 @@ pages:
       - HTML Lang attribute: 'guidelines/web/lang-attribute.md'
       - Use the correct HTML element: 'guidelines/web/correct-element.md'
     - Apps: 'guidelines/apps.md'
+  - Testing:
+    - Web:
+      - Keyboard navigation: 'testing/web/keyboard-navigation.md'
+      - Screen readers: 'testing/web/screen-readers.md'
 theme: readthedocs


### PR DESCRIPTION
To encourage developers to test their work is accessible, this change introduces some accessibility testing notes. These will help guide developers through a manual accessibility test for the following:

- Keyboard navigation
- Screen readers
- Colour contrast

This list is not intended to be exhaustive. For now, I would expect developers to run through these tests at the end of a piece of work, before raising a pull request, to ensure they have covered the bare minimum accessibility requirements.

c/c @guardian/accessibility 